### PR TITLE
feat: add a link to "careers" in the footer

### DIFF
--- a/src/data/site.json
+++ b/src/data/site.json
@@ -39,6 +39,10 @@
           "url": "https://dev.fingerprintjs.com/docs/privacy-policy"
         },
         {
+          "title": "Careers",
+          "url": "https://fingerprintjs.breezy.hr/"
+        },
+        {
           "title": "Log In",
           "url": "https://dashboard.fingerprintjs.com/login"
         }


### PR DESCRIPTION
Added a "Careers" link to the footer that opens `https://fingerprintjs.breezy.hr/` in a new tab.