### PR TITLE
fix: prevent visit ID info icon from breaking line

### DIFF
--- a/src/js/fpjs-widget.js
+++ b/src/js/fpjs-widget.js
@@ -241,7 +241,7 @@ function getVisitTitle(timestamp, now = Date.now()) {
     return pluralize(secondsDiff / (60 * 60 * 24), 'day ago', 'days ago');
   }
 
-  return new Date(timestamp).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+  return new Date(timestamp).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
 }
 
 function getBrowserName({ browserName, browserVersion, os, osVersion, device }) {


### PR DESCRIPTION
Visit title now uses short month names, keeping the visit list narrow.