### PR TITLE
fixing scrolling issue when menu mobile is open

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -23,13 +23,9 @@ export default function Header() {
 
   useEffect(() => {
     const mobileBodyClass = 'isMobileMenuOpen'
-    if (isBrowser && isMobileMenuOpen) {
-      document.body.classList.add(mobileBodyClass)
-      document.body.style.overflow = 'hidden'
-    } else {
-      document.body.classList.remove(mobileBodyClass)
-      document.body.style.overflow = 'unset'
-    }
+    isBrowser && isMobileMenuOpen
+      ? document.body.classList.add(mobileBodyClass)
+      : document.body.classList.remove(mobileBodyClass)
   }, [isMobileMenuOpen])
 
   useEffect(() => {

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -23,9 +23,11 @@ export default function Header() {
 
   useEffect(() => {
     const mobileBodyClass = 'isMobileMenuOpen'
-    isBrowser && isMobileMenuOpen
-      ? document.body.classList.add(mobileBodyClass)
-      : document.body.classList.remove(mobileBodyClass)
+    if (isBrowser && isMobileMenuOpen) {
+      document.body.classList.add(mobileBodyClass)
+    } else {
+      document.body.classList.remove(mobileBodyClass)
+    }
   }, [isMobileMenuOpen])
 
   useEffect(() => {

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -23,9 +23,13 @@ export default function Header() {
 
   useEffect(() => {
     const mobileBodyClass = 'isMobileMenuOpen'
-    isBrowser && isMobileMenuOpen
-      ? document.body.classList.add(mobileBodyClass)
-      : document.body.classList.remove(mobileBodyClass)
+    if (isBrowser && isMobileMenuOpen) {
+      document.body.classList.add(mobileBodyClass)
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.classList.remove(mobileBodyClass)
+      document.body.style.overflow = 'unset'
+    }
   }, [isMobileMenuOpen])
 
   useEffect(() => {

--- a/src/components/MobileNavbar/MobileNavbar.module.scss
+++ b/src/components/MobileNavbar/MobileNavbar.module.scss
@@ -36,6 +36,7 @@
     &.top {
       display: flex;
       justify-content: space-between;
+      flex: none;
 
       > * {
         flex: 1;

--- a/src/components/MobileNavbar/MobileNavbar.module.scss
+++ b/src/components/MobileNavbar/MobileNavbar.module.scss
@@ -86,6 +86,7 @@
     justify-content: space-between;
     align-items: flex-end;
     flex-direction: row-reverse;
+    flex: none;
 
     > span {
       height: 28px;

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -11,6 +11,8 @@ interface ModalProps {
 }
 export default function Modal({ title, open, children, onClose }: ModalProps) {
   const wrapperRef = useRef(null)
+  const overflowRef = useRef<string | null>(null)
+
   useEffect(() => {
     function onWrapperClicked(event) {
       if (wrapperRef.current && wrapperRef.current === event.target) {
@@ -25,7 +27,12 @@ export default function Modal({ title, open, children, onClose }: ModalProps) {
   }, [onClose, wrapperRef])
 
   useEffect(() => {
-    document.body.style.overflow = open ? 'hidden' : 'unset'
+    if (open) {
+      overflowRef.current = document.body.style.overflow
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = overflowRef.current ?? ''
+    }
   }, [open])
 
   return open

--- a/src/styles/global-styles.scss
+++ b/src/styles/global-styles.scss
@@ -35,7 +35,7 @@ body {
   min-height: 100vh;
 
   &.isMobileMenuOpen {
-    overflow: hidden !important;
+    overflow: hidden ;
   }
 }
 

--- a/src/styles/global-styles.scss
+++ b/src/styles/global-styles.scss
@@ -35,7 +35,7 @@ body {
   min-height: 100vh;
 
   &.isMobileMenuOpen {
-    overflow: hidden ;
+    overflow: hidden;
   }
 }
 

--- a/src/styles/global-styles.scss
+++ b/src/styles/global-styles.scss
@@ -36,6 +36,7 @@ body {
 
   &.isMobileMenuOpen {
     overflow: hidden;
+    position: fixed;
   }
 }
 

--- a/src/styles/global-styles.scss
+++ b/src/styles/global-styles.scss
@@ -35,8 +35,7 @@ body {
   min-height: 100vh;
 
   &.isMobileMenuOpen {
-    overflow: hidden;
-    position: fixed;
+    overflow: hidden !important;
   }
 }
 


### PR DESCRIPTION
Added **position:fixed** to css to disable scrolling the document body when the mobile menu is open
Closes WEB-65