### PR TITLE
Changed Netlify referrer policy

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -124,6 +124,19 @@ module.exports = {
         modulePath: `${__dirname}/src/cms/cms.js`,
       },
     },
-    'gatsby-plugin-netlify', // make sure to keep it last in the array
+    {
+      resolve: 'gatsby-plugin-netlify', // make sure to keep it last in the array
+      options: {
+        mergeSecurityHeaders: false,
+        headers: {
+          '/*': [
+            `X-Frame-Options: DENY`,
+            `X-XSS-Protection: 1; mode=block`,
+            `X-Content-Type-Options: nosniff`,
+            `Referrer-Policy: no-referrer-when-downgrade`,
+          ],
+        },
+      },
+    },
   ],
 }


### PR DESCRIPTION
Netlify's default referrer policy is `same-origin` which would classify any visits coming from other origins as direct traffic.
This PR applies the fix from here: https://github.com/gatsbyjs/gatsby/pull/13452#issuecomment-491220468

Closes WEB-103

