### PR TITLE
fix: fixed deploy preview demo

### DIFF
--- a/src/constants/env.ts
+++ b/src/constants/env.ts
@@ -12,16 +12,24 @@ export const FPJS_TOKEN =
     [NetlifyContext.Production]: process.env.GATSBY_FPJS_TOKEN,
     [NetlifyContext.DeployPreview]: process.env.GATSBY_PREVIEW_FPJS_TOKEN,
   }) ?? 'test_client_token'
+
 export const FPJS_API_TOKEN =
   getContextEnv<string>({
     [NetlifyContext.Production]: process.env.GATSBY_FPJS_API_TOKEN,
     [NetlifyContext.DeployPreview]: process.env.GATSBY_PREVIEW_API_TOKEN,
   }) ?? 'test_fpjs_api_token'
+
 export const FPJS_ENDPOINT =
   getContextEnv<string>({
     [NetlifyContext.Production]: process.env.GATSBY_FPJS_ENDPOINT,
     [NetlifyContext.DeployPreview]: process.env.GATSBY_PREVIEW_FPJS_ENDPOINT,
   }) ?? ''
+
+export const TLS_ENDPOINT = getContextEnv<string>({
+  [NetlifyContext.Production]: process.env.GATSBY_TLS_ENDPOINT,
+  [NetlifyContext.DeployPreview]: process.env.GATSBY_PREVIEW_TLS_ENDPOINT,
+})
+
 export const FPJS_REGION = process.env.GATSBY_FPJS_REGION
 export const FPJS_DASHBOARD_ENDPOINT = process.env.GATSBY_FPJS_DASHBOARD_ENDPOINT
 export const FPJS_MONITORING_CLIENT_ID = process.env.GATSBY_FPJS_MONITORING_CLIENT_ID

--- a/src/context/FpjsContext.tsx
+++ b/src/context/FpjsContext.tsx
@@ -6,6 +6,7 @@ import {
   FPJS_REGION,
   FPJS_MONITORING_CLIENT_ID,
   FPJS_MONITORING_TOKEN,
+  TLS_ENDPOINT,
 } from '../constants/env'
 
 const FpjsContext = React.createContext<{ visitorData?: FullIpExtendedGetResult }>({})
@@ -23,6 +24,8 @@ export function FpjsProvider({ children }: { children: React.ReactNode }) {
   const region = FPJS_REGION as Region
   const monitoringClientId = FPJS_MONITORING_CLIENT_ID ?? ''
   const monitoringToken = FPJS_MONITORING_TOKEN ?? ''
+  const tlsEndpoint = TLS_ENDPOINT
+
   const [visitorData, setVisitorData] = useState<FullIpExtendedGetResult>()
 
   useEffect(() => {
@@ -32,6 +35,7 @@ export function FpjsProvider({ children }: { children: React.ReactNode }) {
         token: clientToken,
         endpoint,
         region,
+        tlsEndpoint,
 
         // It may break after a @fingerprintjs/fingerprintjs-pro update. Please check when updating.
         debug: monitoringToken
@@ -44,7 +48,7 @@ export function FpjsProvider({ children }: { children: React.ReactNode }) {
     }
 
     getVisitorData()
-  }, [clientToken, endpoint, region, monitoringClientId, monitoringToken])
+  }, [clientToken, endpoint, tlsEndpoint, region, monitoringClientId, monitoringToken])
 
   return <FpjsContext.Provider value={{ visitorData }}>{children}</FpjsContext.Provider>
 }


### PR DESCRIPTION
Added TLS param for fpjs calls, we should use staging TLS endpoint for the deploy preview