### PR TITLE
fix: problem with images that don't render well in blog articles 

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -91,17 +91,10 @@ module.exports = {
             },
           },
           {
-            resolve: `gatsby-transformer-remark`,
+            resolve: `gatsby-remark-highlight-code`,
             options: {
-              plugins: [
-                {
-                  resolve: `gatsby-remark-highlight-code`,
-                  options: {
-                    terminal: 'carbon',
-                    lineNumbers: false,
-                  },
-                },
-              ],
+              terminal: 'carbon',
+              lineNumbers: false,
             },
           },
         ],


### PR DESCRIPTION
Closes WEB-121
removed 2nd transformer remark plugin that was causing the problem