### PR TITLE
Set up JS agent error Rollbar monitoring

### DIFF
--- a/src/components/FpjsWidget/index.tsx
+++ b/src/components/FpjsWidget/index.tsx
@@ -43,7 +43,7 @@ export default memo(function FpjsWidget() {
           setCurrentVisit(visits[0])
         }
       } catch (e) {
-        rollbar.error('Unable to initialize FingerprintJS Pro', e)
+        rollbar.error('Unable to load visits', e)
       } finally {
         if (!isCancelled) {
           setIsLoading(false)

--- a/src/context/FpjsContext.tsx
+++ b/src/context/FpjsContext.tsx
@@ -30,21 +30,27 @@ export function FpjsProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     async function getVisitorData() {
-      const FP = await import('@fingerprintjs/fingerprintjs-pro')
-      const fp = await FP.load({
-        token: clientToken,
-        endpoint,
-        region,
-        tlsEndpoint,
+      try {
+        const FP = await import('@fingerprintjs/fingerprintjs-pro')
+        const fp = await FP.load({
+          token: clientToken,
+          endpoint,
+          region,
+          tlsEndpoint,
 
-        // It may break after a @fingerprintjs/fingerprintjs-pro update. Please check when updating.
-        debug: monitoringToken
-          ? FP.makeRemoteDebugger({ clientId: monitoringClientId, token: monitoringToken })
-          : undefined,
-      })
-      const result = await fp.get(config)
-
-      setVisitorData(result)
+          // It may break after a @fingerprintjs/fingerprintjs-pro update. Please check when updating.
+          debug: monitoringToken
+            ? FP.makeRemoteDebugger({ clientId: monitoringClientId, token: monitoringToken })
+            : undefined,
+        })
+        const result = await fp.get(config)
+        setVisitorData(result)
+      } catch (error) {
+        // Adds a special name to JS agent errors so that they can be found in Rollbar easily.
+        error.message = `${error.name}: ${error.message}`
+        error.name = 'FPJSAgentError'
+        throw error
+      }
     }
 
     getVisitorData()


### PR DESCRIPTION
Resolves https://fpjs.myjetbrains.com/youtrack/issue/JSAGENT-145

JS agent errors require a separate not-throttle monitoring channel. I and Artem have decided to use the [existing website Rollbar monitoring system](https://rollbar.com/fpjs/all/items/?rojects=319827) and add an explicit trait to JS agent errors to make them easier to find.