### PR TITLE
fix: another CSP iteration

### DIFF
--- a/config/csp-config.js
+++ b/config/csp-config.js
@@ -1,0 +1,38 @@
+const isProdContext = process.env.CONTEXT === 'production' // can't use env helper from TS sources here
+
+const cspProdValues = {
+  scriptSrc:
+    "'self' 'sha256-kg92jgSA2EzM8AwnuekOuCBD3CO3Kbuysg5lIK9ZfSw=' 'sha256-zqIPI2g2ugmfel4J2XUMoQXIW4bR24iUgHjY714X0t8=' 'sha256-I8vNagfhtdBQM+h81pU4RVtKqzUmg18j7D+bD6umWoQ=' 'sha256-BlU3vSjtWCRb01JYtwFVwEn79C0VxILDgBS63iIXwM8=' 'sha256-6nixeeU2hi3MrSIjmGOq9yke14lrSwQbK5WkcJtIyU8=' 'sha256-xI1BcEci8jncUxYekf4P+TCNf5sIZW5qGF7D7oVMN1E=' 'sha256-Uz0yn00PqpvyPuK+MptaAirzRCPwuCU4Vhj/iAbfJxk=' 'sha256-cveTYmMF4Qjo/PsaU4HqenqlgU4hSXQEa8iFe7Hqzto='  https://analytics.twitter.com https://platform.twitter.com https://api.olark.com https://static.olark.com https://assets.olark.com https://connect.facebook.net https://nrpc.olark.com https://snap.licdn.com https://static.ads-twitter.com https://www.googleadservices.com https://www.google.com https://www.google-analytics.com https://ssl.google-analytics.com https://www.googletagmanager.com https://tagmanager.google.com",
+  connectSrc:
+    "'self' https://api.fpjs.pro https://api.github.com https://api.rollbar.com https://api.sjpf.io https://f.fingerprintjs.com https://nrpc.olark.com https://www.google-analytics.com",
+  frameSrc: "'self' https://static.olark.com;",
+}
+const cspStagingValues = {
+  scriptSrc:
+    "'self' 'sha256-xpUFDIKSffkTJajaomahRIRbTZ5aW5oJw10d1Q1T1WE=' 'sha256-gRdRAul2Q8J0Xw90SMORyALbYkU6lngGwcY6SI+MADU=' 'sha256-z2F9SsbN7syf0vOuFTXVMH4enBntY4ZiiRbqj7KLg94=' 'sha256-G0jEfREnRnoHO7+3Y0228H/ntgRqVj76vXyfNtfUwoI=' 'sha256-egpbluqkD8NT0bY3bWy7raM9tRIMkfUWboq0Y8KqsFk=' 'sha256-fNL7JskeQYqtSCaMxLwNZeEdaadRJxEEAkbFZDyBY7U=' https://analytics.twitter.com https://platform.twitter.com https://api.olark.com https://static.olark.com https://assets.olark.com https://netlify-cdp-loader.netlify.app https://connect.facebook.net https://nrpc.olark.com https://snap.licdn.com https://static.ads-twitter.com https://www.googleadservices.com https://www.google.com https://www.google-analytics.com https://ssl.google-analytics.com https://www.googletagmanager.com https://tagmanager.google.com",
+  connectSrc:
+    "'self' https://coreapi.fpjs.sh https://api.github.com https://api.rollbar.com https://staging.cache.fpjs.sh https://f.fingerprintjs.com https://nrpc.olark.com https://www.google-analytics.com",
+  frameSrc: "'self' https://app.netlify.com https://static.olark.com",
+}
+const cspValues = isProdContext ? cspProdValues : cspStagingValues
+
+module.exports = {
+  disableOnDev: true,
+  mergeScriptHashes: true, // you can disable scripts sha256 hashes
+  mergeStyleHashes: false, // disable styles sha256 hashes to allow unsafe-inline
+  mergeDefaultDirectives: true,
+  directives: {
+    'script-src': cspValues.scriptSrc,
+    'connect-src': cspValues.connectSrc,
+    'frame-src': cspValues.frameSrc,
+    'style-src':
+      "'report-sample' 'self' 'unsafe-inline' https://fonts.googleapis.com https://tagmanager.google.com https://static.olark.com",
+    'img-src':
+      "'self' data: https://api.mapbox.com https://i.imgur.com https://log.olark.com https://px.ads.linkedin.com https://p.adsymptotic.com https://t.co https://www.facebook.com https://googleads.g.doubleclick.net  https://www.google.com https://www.google-analytics.com https://ssl.gstatic.com https://www.gstatic.com",
+    'font-src': "'self' data: https://fonts.gstatic.com https://static.olark.com",
+    'manifest-src': "'self'",
+    'media-src': "'self' https://static.olark.com",
+    'worker-src': "'none'",
+    'upgrade-insecure-requests': '',
+  },
+}

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -170,7 +170,7 @@ module.exports = {
       resolve: `gatsby-plugin-csp`,
       options: {
         disableOnDev: true,
-        reportOnly: true, // Changes header to Content-Security-Policy-Report-Only for csp testing purposes
+        // reportOnly: true, // Changes header to Content-Security-Policy-Report-Only for csp testing purposes
         mergeScriptHashes: true, // you can disable scripts sha256 hashes
         mergeStyleHashes: true, // you can disable styles sha256 hashes
         mergeDefaultDirectives: true,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,9 +4,23 @@ const baseUrl = 'https://fingerprintjs.com'
 
 const isProdContext = process.env.CONTEXT === 'production' // can't use env helper from TS sources here
 
-const cspValueStaging = `default-src 'self'; script-src 'report-sample' 'self' 'sha256-xpUFDIKSffkTJajaomahRIRbTZ5aW5oJw10d1Q1T1WE=' 'sha256-gRdRAul2Q8J0Xw90SMORyALbYkU6lngGwcY6SI+MADU=' 'sha256-z2F9SsbN7syf0vOuFTXVMH4enBntY4ZiiRbqj7KLg94=' 'sha256-G0jEfREnRnoHO7+3Y0228H/ntgRqVj76vXyfNtfUwoI=' 'sha256-egpbluqkD8NT0bY3bWy7raM9tRIMkfUWboq0Y8KqsFk=' 'sha256-fNL7JskeQYqtSCaMxLwNZeEdaadRJxEEAkbFZDyBY7U=' https://analytics.twitter.com https://platform.twitter.com https://api.olark.com https://static.olark.com https://assets.olark.com https://netlify-cdp-loader.netlify.app https://connect.facebook.net https://nrpc.olark.com https://snap.licdn.com https://static.ads-twitter.com https://www.googleadservices.com https://www.google.com https://www.google-analytics.com https://ssl.google-analytics.com https://www.googletagmanager.com https://tagmanager.google.com; style-src 'report-sample' 'self' 'unsafe-inline' https://fonts.googleapis.com https://tagmanager.google.com https://static.olark.com; object-src 'none'; base-uri 'self'; connect-src 'self' https://coreapi.fpjs.sh https://api.github.com https://api.rollbar.com https://staging.cache.fpjs.sh https://f.fingerprintjs.com https://nrpc.olark.com https://www.google-analytics.com; font-src 'self' data: https://fonts.gstatic.com https://static.olark.com; frame-src 'self' https://app.netlify.com https://static.olark.com; img-src 'self' data: https://api.mapbox.com https://i.imgur.com https://log.olark.com https://px.ads.linkedin.com https://p.adsymptotic.com https://t.co https://www.facebook.com https://googleads.g.doubleclick.net  https://www.google.com https://www.google-analytics.com https://ssl.gstatic.com https://www.gstatic.com; manifest-src 'self'; media-src 'self' https://static.olark.com; report-uri https://mgmtapi.fpjs.sh/_/csp-reports; worker-src 'none'; frame-ancestors 'none'; upgrade-insecure-requests; form-action 'none';`
-const cspValueProd = `default-src 'self'; script-src 'report-sample' 'self' 'unsafe-inline' 'sha256-kg92jgSA2EzM8AwnuekOuCBD3CO3Kbuysg5lIK9ZfSw=' 'sha256-zqIPI2g2ugmfel4J2XUMoQXIW4bR24iUgHjY714X0t8=' 'sha256-I8vNagfhtdBQM+h81pU4RVtKqzUmg18j7D+bD6umWoQ=' 'sha256-BlU3vSjtWCRb01JYtwFVwEn79C0VxILDgBS63iIXwM8=' 'sha256-6nixeeU2hi3MrSIjmGOq9yke14lrSwQbK5WkcJtIyU8=' 'sha256-xI1BcEci8jncUxYekf4P+TCNf5sIZW5qGF7D7oVMN1E=' 'sha256-Uz0yn00PqpvyPuK+MptaAirzRCPwuCU4Vhj/iAbfJxk=' 'sha256-cveTYmMF4Qjo/PsaU4HqenqlgU4hSXQEa8iFe7Hqzto='  https://analytics.twitter.com https://platform.twitter.com https://api.olark.com https://static.olark.com https://assets.olark.com https://connect.facebook.net https://nrpc.olark.com https://snap.licdn.com https://static.ads-twitter.com https://www.googleadservices.com https://www.google.com https://www.google-analytics.com https://ssl.google-analytics.com https://www.googletagmanager.com https://tagmanager.google.com; style-src 'report-sample' 'self' 'unsafe-inline' https://fonts.googleapis.com https://tagmanager.google.com https://static.olark.com; object-src 'none'; base-uri 'self'; connect-src 'self' https://api.fpjs.pro https://api.github.com https://api.rollbar.com https://api.sjpf.io https://f.fingerprintjs.com https://nrpc.olark.com https://www.google-analytics.com; font-src 'self' data: https://fonts.gstatic.com https://static.olark.com; frame-src 'self' https://static.olark.com; img-src 'self' data: https://api.mapbox.com https://i.imgur.com https://log.olark.com https://px.ads.linkedin.com https://p.adsymptotic.com https://t.co https://www.facebook.com https://googleads.g.doubleclick.net  https://www.google.com https://www.google-analytics.com https://ssl.gstatic.com https://www.gstatic.com; manifest-src 'self'; media-src 'self' https://static.olark.com; report-uri https://api.fpjs.pro/_/csp-reports; worker-src 'none'; frame-ancestors 'none'; upgrade-insecure-requests; form-action 'none';`
-const cspValue = isProdContext ? cspValueProd : cspValueStaging
+const cspProdValues = {
+  scriptSrc:
+    "'sha256-kg92jgSA2EzM8AwnuekOuCBD3CO3Kbuysg5lIK9ZfSw=' 'sha256-zqIPI2g2ugmfel4J2XUMoQXIW4bR24iUgHjY714X0t8=' 'sha256-I8vNagfhtdBQM+h81pU4RVtKqzUmg18j7D+bD6umWoQ=' 'sha256-BlU3vSjtWCRb01JYtwFVwEn79C0VxILDgBS63iIXwM8=' 'sha256-6nixeeU2hi3MrSIjmGOq9yke14lrSwQbK5WkcJtIyU8=' 'sha256-xI1BcEci8jncUxYekf4P+TCNf5sIZW5qGF7D7oVMN1E=' 'sha256-Uz0yn00PqpvyPuK+MptaAirzRCPwuCU4Vhj/iAbfJxk=' 'sha256-cveTYmMF4Qjo/PsaU4HqenqlgU4hSXQEa8iFe7Hqzto='  https://analytics.twitter.com https://platform.twitter.com https://api.olark.com https://static.olark.com https://assets.olark.com https://connect.facebook.net https://nrpc.olark.com https://snap.licdn.com https://static.ads-twitter.com https://www.googleadservices.com https://www.google.com https://www.google-analytics.com https://ssl.google-analytics.com https://www.googletagmanager.com https://tagmanager.google.com",
+  connectSrc:
+    "'self' https://api.fpjs.pro https://api.github.com https://api.rollbar.com https://api.sjpf.io https://f.fingerprintjs.com https://nrpc.olark.com https://www.google-analytics.com",
+  frameSrc: "frame-src 'self' https://static.olark.com;",
+  reportUri: 'https://api.fpjs.pro/_/csp-reports;',
+}
+const cspStagingValues = {
+  scriptSrc:
+    "'sha256-xpUFDIKSffkTJajaomahRIRbTZ5aW5oJw10d1Q1T1WE=' 'sha256-gRdRAul2Q8J0Xw90SMORyALbYkU6lngGwcY6SI+MADU=' 'sha256-z2F9SsbN7syf0vOuFTXVMH4enBntY4ZiiRbqj7KLg94=' 'sha256-G0jEfREnRnoHO7+3Y0228H/ntgRqVj76vXyfNtfUwoI=' 'sha256-egpbluqkD8NT0bY3bWy7raM9tRIMkfUWboq0Y8KqsFk=' 'sha256-fNL7JskeQYqtSCaMxLwNZeEdaadRJxEEAkbFZDyBY7U=' https://analytics.twitter.com https://platform.twitter.com https://api.olark.com https://static.olark.com https://assets.olark.com https://netlify-cdp-loader.netlify.app https://connect.facebook.net https://nrpc.olark.com https://snap.licdn.com https://static.ads-twitter.com https://www.googleadservices.com https://www.google.com https://www.google-analytics.com https://ssl.google-analytics.com https://www.googletagmanager.com https://tagmanager.google.com",
+  connectSrc:
+    "'self' https://coreapi.fpjs.sh https://api.github.com https://api.rollbar.com https://staging.cache.fpjs.sh https://f.fingerprintjs.com https://nrpc.olark.com https://www.google-analytics.com",
+  frameSrc: "frame-src 'self' https://app.netlify.com https://static.olark.com",
+  reportUri: 'https://mgmtapi.fpjs.sh/_/csp-reports',
+}
+const cspScriptValues = isProdContext ? cspProdValues : cspStagingValues
 
 const resolvePath = (directoryName, pathName) => {
   const result = path.join(directoryName, pathName)
@@ -147,9 +161,34 @@ module.exports = {
             `X-Frame-Options: DENY`,
             `X-XSS-Protection: 1; mode=block`,
             `X-Content-Type-Options: nosniff`,
-            `Content-Security-Policy-Report-Only: ${cspValue}`,
             `Referrer-Policy: no-referrer-when-downgrade`,
           ],
+        },
+      },
+    },
+    {
+      resolve: `gatsby-plugin-csp`,
+      options: {
+        disableOnDev: true,
+        reportOnly: true, // Changes header to Content-Security-Policy-Report-Only for csp testing purposes
+        mergeScriptHashes: true, // you can disable scripts sha256 hashes
+        mergeStyleHashes: true, // you can disable styles sha256 hashes
+        mergeDefaultDirectives: true,
+        directives: {
+          'script-src': cspScriptValues.scriptSrc,
+          'connect-src': cspScriptValues.connectSrc,
+          'frame-src': cspProdValues.frameSrc,
+          'report-uri': cspProdValues.reportUri,
+          'style-src':
+            "'report-sample' 'self' 'unsafe-inline' https://fonts.googleapis.com https://tagmanager.google.com https://static.olark.com",
+          'img-src':
+            "'self' data: https://api.mapbox.com https://i.imgur.com https://log.olark.com https://px.ads.linkedin.com https://p.adsymptotic.com https://t.co https://www.facebook.com https://googleads.g.doubleclick.net  https://www.google.com https://www.google-analytics.com https://ssl.gstatic.com https://www.gstatic.com",
+          'font-src': "'self' data: https://fonts.gstatic.com https://static.olark.com",
+          'manifest-src': "'self'",
+          'media-src': "'self' https://static.olark.com'",
+          'worker-src': "'none'",
+          'frame-ancestors': "'none'",
+          'upgrade-insecure-requests': '',
         },
       },
     },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -9,18 +9,16 @@ const cspProdValues = {
     "'sha256-kg92jgSA2EzM8AwnuekOuCBD3CO3Kbuysg5lIK9ZfSw=' 'sha256-zqIPI2g2ugmfel4J2XUMoQXIW4bR24iUgHjY714X0t8=' 'sha256-I8vNagfhtdBQM+h81pU4RVtKqzUmg18j7D+bD6umWoQ=' 'sha256-BlU3vSjtWCRb01JYtwFVwEn79C0VxILDgBS63iIXwM8=' 'sha256-6nixeeU2hi3MrSIjmGOq9yke14lrSwQbK5WkcJtIyU8=' 'sha256-xI1BcEci8jncUxYekf4P+TCNf5sIZW5qGF7D7oVMN1E=' 'sha256-Uz0yn00PqpvyPuK+MptaAirzRCPwuCU4Vhj/iAbfJxk=' 'sha256-cveTYmMF4Qjo/PsaU4HqenqlgU4hSXQEa8iFe7Hqzto='  https://analytics.twitter.com https://platform.twitter.com https://api.olark.com https://static.olark.com https://assets.olark.com https://connect.facebook.net https://nrpc.olark.com https://snap.licdn.com https://static.ads-twitter.com https://www.googleadservices.com https://www.google.com https://www.google-analytics.com https://ssl.google-analytics.com https://www.googletagmanager.com https://tagmanager.google.com",
   connectSrc:
     "'self' https://api.fpjs.pro https://api.github.com https://api.rollbar.com https://api.sjpf.io https://f.fingerprintjs.com https://nrpc.olark.com https://www.google-analytics.com",
-  frameSrc: "frame-src 'self' https://static.olark.com;",
-  reportUri: 'https://api.fpjs.pro/_/csp-reports;',
+  frameSrc: "'self' https://static.olark.com;",
 }
 const cspStagingValues = {
   scriptSrc:
     "'sha256-xpUFDIKSffkTJajaomahRIRbTZ5aW5oJw10d1Q1T1WE=' 'sha256-gRdRAul2Q8J0Xw90SMORyALbYkU6lngGwcY6SI+MADU=' 'sha256-z2F9SsbN7syf0vOuFTXVMH4enBntY4ZiiRbqj7KLg94=' 'sha256-G0jEfREnRnoHO7+3Y0228H/ntgRqVj76vXyfNtfUwoI=' 'sha256-egpbluqkD8NT0bY3bWy7raM9tRIMkfUWboq0Y8KqsFk=' 'sha256-fNL7JskeQYqtSCaMxLwNZeEdaadRJxEEAkbFZDyBY7U=' https://analytics.twitter.com https://platform.twitter.com https://api.olark.com https://static.olark.com https://assets.olark.com https://netlify-cdp-loader.netlify.app https://connect.facebook.net https://nrpc.olark.com https://snap.licdn.com https://static.ads-twitter.com https://www.googleadservices.com https://www.google.com https://www.google-analytics.com https://ssl.google-analytics.com https://www.googletagmanager.com https://tagmanager.google.com",
   connectSrc:
     "'self' https://coreapi.fpjs.sh https://api.github.com https://api.rollbar.com https://staging.cache.fpjs.sh https://f.fingerprintjs.com https://nrpc.olark.com https://www.google-analytics.com",
-  frameSrc: "frame-src 'self' https://app.netlify.com https://static.olark.com",
-  reportUri: 'https://mgmtapi.fpjs.sh/_/csp-reports',
+  frameSrc: "'self' https://app.netlify.com https://static.olark.com",
 }
-const cspScriptValues = isProdContext ? cspProdValues : cspStagingValues
+const cspValues = isProdContext ? cspProdValues : cspStagingValues
 
 const resolvePath = (directoryName, pathName) => {
   const result = path.join(directoryName, pathName)
@@ -175,10 +173,9 @@ module.exports = {
         mergeStyleHashes: true, // you can disable styles sha256 hashes
         mergeDefaultDirectives: true,
         directives: {
-          'script-src': cspScriptValues.scriptSrc,
-          'connect-src': cspScriptValues.connectSrc,
-          'frame-src': cspProdValues.frameSrc,
-          'report-uri': cspProdValues.reportUri,
+          'script-src': cspValues.scriptSrc,
+          'connect-src': cspValues.connectSrc,
+          'frame-src': cspValues.frameSrc,
           'style-src':
             "'report-sample' 'self' 'unsafe-inline' https://fonts.googleapis.com https://tagmanager.google.com https://static.olark.com",
           'img-src':

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,24 +1,7 @@
 const path = require('path')
 
 const baseUrl = 'https://fingerprintjs.com'
-
-const isProdContext = process.env.CONTEXT === 'production' // can't use env helper from TS sources here
-
-const cspProdValues = {
-  scriptSrc:
-    "'self' 'sha256-kg92jgSA2EzM8AwnuekOuCBD3CO3Kbuysg5lIK9ZfSw=' 'sha256-zqIPI2g2ugmfel4J2XUMoQXIW4bR24iUgHjY714X0t8=' 'sha256-I8vNagfhtdBQM+h81pU4RVtKqzUmg18j7D+bD6umWoQ=' 'sha256-BlU3vSjtWCRb01JYtwFVwEn79C0VxILDgBS63iIXwM8=' 'sha256-6nixeeU2hi3MrSIjmGOq9yke14lrSwQbK5WkcJtIyU8=' 'sha256-xI1BcEci8jncUxYekf4P+TCNf5sIZW5qGF7D7oVMN1E=' 'sha256-Uz0yn00PqpvyPuK+MptaAirzRCPwuCU4Vhj/iAbfJxk=' 'sha256-cveTYmMF4Qjo/PsaU4HqenqlgU4hSXQEa8iFe7Hqzto='  https://analytics.twitter.com https://platform.twitter.com https://api.olark.com https://static.olark.com https://assets.olark.com https://connect.facebook.net https://nrpc.olark.com https://snap.licdn.com https://static.ads-twitter.com https://www.googleadservices.com https://www.google.com https://www.google-analytics.com https://ssl.google-analytics.com https://www.googletagmanager.com https://tagmanager.google.com",
-  connectSrc:
-    "'self' https://api.fpjs.pro https://api.github.com https://api.rollbar.com https://api.sjpf.io https://f.fingerprintjs.com https://nrpc.olark.com https://www.google-analytics.com",
-  frameSrc: "'self' https://static.olark.com;",
-}
-const cspStagingValues = {
-  scriptSrc:
-    "'self' 'sha256-xpUFDIKSffkTJajaomahRIRbTZ5aW5oJw10d1Q1T1WE=' 'sha256-gRdRAul2Q8J0Xw90SMORyALbYkU6lngGwcY6SI+MADU=' 'sha256-z2F9SsbN7syf0vOuFTXVMH4enBntY4ZiiRbqj7KLg94=' 'sha256-G0jEfREnRnoHO7+3Y0228H/ntgRqVj76vXyfNtfUwoI=' 'sha256-egpbluqkD8NT0bY3bWy7raM9tRIMkfUWboq0Y8KqsFk=' 'sha256-fNL7JskeQYqtSCaMxLwNZeEdaadRJxEEAkbFZDyBY7U=' https://analytics.twitter.com https://platform.twitter.com https://api.olark.com https://static.olark.com https://assets.olark.com https://netlify-cdp-loader.netlify.app https://connect.facebook.net https://nrpc.olark.com https://snap.licdn.com https://static.ads-twitter.com https://www.googleadservices.com https://www.google.com https://www.google-analytics.com https://ssl.google-analytics.com https://www.googletagmanager.com https://tagmanager.google.com",
-  connectSrc:
-    "'self' https://coreapi.fpjs.sh https://api.github.com https://api.rollbar.com https://staging.cache.fpjs.sh https://f.fingerprintjs.com https://nrpc.olark.com https://www.google-analytics.com",
-  frameSrc: "'self' https://app.netlify.com https://static.olark.com",
-}
-const cspValues = isProdContext ? cspProdValues : cspStagingValues
+const cspConfig = require('./config/csp-config')
 
 const resolvePath = (directoryName, pathName) => {
   const result = path.join(directoryName, pathName)
@@ -166,26 +149,7 @@ module.exports = {
     },
     {
       resolve: `gatsby-plugin-csp`,
-      options: {
-        disableOnDev: true,
-        mergeScriptHashes: true, // you can disable scripts sha256 hashes
-        mergeStyleHashes: false, // disable styles sha256 hashes to allow unsafe-inline
-        mergeDefaultDirectives: true,
-        directives: {
-          'script-src': cspValues.scriptSrc,
-          'connect-src': cspValues.connectSrc,
-          'frame-src': cspValues.frameSrc,
-          'style-src':
-            "'report-sample' 'self' 'unsafe-inline' https://fonts.googleapis.com https://tagmanager.google.com https://static.olark.com",
-          'img-src':
-            "'self' data: https://api.mapbox.com https://i.imgur.com https://log.olark.com https://px.ads.linkedin.com https://p.adsymptotic.com https://t.co https://www.facebook.com https://googleads.g.doubleclick.net  https://www.google.com https://www.google-analytics.com https://ssl.gstatic.com https://www.gstatic.com",
-          'font-src': "'self' data: https://fonts.gstatic.com https://static.olark.com",
-          'manifest-src': "'self'",
-          'media-src': "'self' https://static.olark.com",
-          'worker-src': "'none'",
-          'upgrade-insecure-requests': '',
-        },
-      },
+      options: cspConfig,
     },
   ],
   mapping: {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,14 +6,14 @@ const isProdContext = process.env.CONTEXT === 'production' // can't use env help
 
 const cspProdValues = {
   scriptSrc:
-    "'sha256-kg92jgSA2EzM8AwnuekOuCBD3CO3Kbuysg5lIK9ZfSw=' 'sha256-zqIPI2g2ugmfel4J2XUMoQXIW4bR24iUgHjY714X0t8=' 'sha256-I8vNagfhtdBQM+h81pU4RVtKqzUmg18j7D+bD6umWoQ=' 'sha256-BlU3vSjtWCRb01JYtwFVwEn79C0VxILDgBS63iIXwM8=' 'sha256-6nixeeU2hi3MrSIjmGOq9yke14lrSwQbK5WkcJtIyU8=' 'sha256-xI1BcEci8jncUxYekf4P+TCNf5sIZW5qGF7D7oVMN1E=' 'sha256-Uz0yn00PqpvyPuK+MptaAirzRCPwuCU4Vhj/iAbfJxk=' 'sha256-cveTYmMF4Qjo/PsaU4HqenqlgU4hSXQEa8iFe7Hqzto='  https://analytics.twitter.com https://platform.twitter.com https://api.olark.com https://static.olark.com https://assets.olark.com https://connect.facebook.net https://nrpc.olark.com https://snap.licdn.com https://static.ads-twitter.com https://www.googleadservices.com https://www.google.com https://www.google-analytics.com https://ssl.google-analytics.com https://www.googletagmanager.com https://tagmanager.google.com",
+    "'self' 'sha256-kg92jgSA2EzM8AwnuekOuCBD3CO3Kbuysg5lIK9ZfSw=' 'sha256-zqIPI2g2ugmfel4J2XUMoQXIW4bR24iUgHjY714X0t8=' 'sha256-I8vNagfhtdBQM+h81pU4RVtKqzUmg18j7D+bD6umWoQ=' 'sha256-BlU3vSjtWCRb01JYtwFVwEn79C0VxILDgBS63iIXwM8=' 'sha256-6nixeeU2hi3MrSIjmGOq9yke14lrSwQbK5WkcJtIyU8=' 'sha256-xI1BcEci8jncUxYekf4P+TCNf5sIZW5qGF7D7oVMN1E=' 'sha256-Uz0yn00PqpvyPuK+MptaAirzRCPwuCU4Vhj/iAbfJxk=' 'sha256-cveTYmMF4Qjo/PsaU4HqenqlgU4hSXQEa8iFe7Hqzto='  https://analytics.twitter.com https://platform.twitter.com https://api.olark.com https://static.olark.com https://assets.olark.com https://connect.facebook.net https://nrpc.olark.com https://snap.licdn.com https://static.ads-twitter.com https://www.googleadservices.com https://www.google.com https://www.google-analytics.com https://ssl.google-analytics.com https://www.googletagmanager.com https://tagmanager.google.com",
   connectSrc:
     "'self' https://api.fpjs.pro https://api.github.com https://api.rollbar.com https://api.sjpf.io https://f.fingerprintjs.com https://nrpc.olark.com https://www.google-analytics.com",
   frameSrc: "'self' https://static.olark.com;",
 }
 const cspStagingValues = {
   scriptSrc:
-    "'sha256-xpUFDIKSffkTJajaomahRIRbTZ5aW5oJw10d1Q1T1WE=' 'sha256-gRdRAul2Q8J0Xw90SMORyALbYkU6lngGwcY6SI+MADU=' 'sha256-z2F9SsbN7syf0vOuFTXVMH4enBntY4ZiiRbqj7KLg94=' 'sha256-G0jEfREnRnoHO7+3Y0228H/ntgRqVj76vXyfNtfUwoI=' 'sha256-egpbluqkD8NT0bY3bWy7raM9tRIMkfUWboq0Y8KqsFk=' 'sha256-fNL7JskeQYqtSCaMxLwNZeEdaadRJxEEAkbFZDyBY7U=' https://analytics.twitter.com https://platform.twitter.com https://api.olark.com https://static.olark.com https://assets.olark.com https://netlify-cdp-loader.netlify.app https://connect.facebook.net https://nrpc.olark.com https://snap.licdn.com https://static.ads-twitter.com https://www.googleadservices.com https://www.google.com https://www.google-analytics.com https://ssl.google-analytics.com https://www.googletagmanager.com https://tagmanager.google.com",
+    "'self' 'sha256-xpUFDIKSffkTJajaomahRIRbTZ5aW5oJw10d1Q1T1WE=' 'sha256-gRdRAul2Q8J0Xw90SMORyALbYkU6lngGwcY6SI+MADU=' 'sha256-z2F9SsbN7syf0vOuFTXVMH4enBntY4ZiiRbqj7KLg94=' 'sha256-G0jEfREnRnoHO7+3Y0228H/ntgRqVj76vXyfNtfUwoI=' 'sha256-egpbluqkD8NT0bY3bWy7raM9tRIMkfUWboq0Y8KqsFk=' 'sha256-fNL7JskeQYqtSCaMxLwNZeEdaadRJxEEAkbFZDyBY7U=' https://analytics.twitter.com https://platform.twitter.com https://api.olark.com https://static.olark.com https://assets.olark.com https://netlify-cdp-loader.netlify.app https://connect.facebook.net https://nrpc.olark.com https://snap.licdn.com https://static.ads-twitter.com https://www.googleadservices.com https://www.google.com https://www.google-analytics.com https://ssl.google-analytics.com https://www.googletagmanager.com https://tagmanager.google.com",
   connectSrc:
     "'self' https://coreapi.fpjs.sh https://api.github.com https://api.rollbar.com https://staging.cache.fpjs.sh https://f.fingerprintjs.com https://nrpc.olark.com https://www.google-analytics.com",
   frameSrc: "'self' https://app.netlify.com https://static.olark.com",
@@ -168,9 +168,8 @@ module.exports = {
       resolve: `gatsby-plugin-csp`,
       options: {
         disableOnDev: true,
-        // reportOnly: true, // Changes header to Content-Security-Policy-Report-Only for csp testing purposes
         mergeScriptHashes: true, // you can disable scripts sha256 hashes
-        mergeStyleHashes: true, // you can disable styles sha256 hashes
+        mergeStyleHashes: false, // disable styles sha256 hashes to allow unsafe-inline
         mergeDefaultDirectives: true,
         directives: {
           'script-src': cspValues.scriptSrc,
@@ -182,9 +181,8 @@ module.exports = {
             "'self' data: https://api.mapbox.com https://i.imgur.com https://log.olark.com https://px.ads.linkedin.com https://p.adsymptotic.com https://t.co https://www.facebook.com https://googleads.g.doubleclick.net  https://www.google.com https://www.google-analytics.com https://ssl.gstatic.com https://www.gstatic.com",
           'font-src': "'self' data: https://fonts.gstatic.com https://static.olark.com",
           'manifest-src': "'self'",
-          'media-src': "'self' https://static.olark.com'",
+          'media-src': "'self' https://static.olark.com",
           'worker-src': "'none'",
-          'frame-ancestors': "'none'",
           'upgrade-insecure-requests': '',
         },
       },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "gatsby-background-image": "^1.3.1",
     "gatsby-image": "^2.3.5",
     "gatsby-plugin-breadcrumb": "^10.0.0",
+    "gatsby-plugin-csp": "^1.1.3",
     "gatsby-plugin-env-variables": "^2.0.0",
     "gatsby-plugin-netlify": "^2.4.0",
     "gatsby-plugin-netlify-cms": "^4.3.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9601,6 +9601,14 @@ gatsby-plugin-breadcrumb@^10.0.0:
     identity-obj-proxy "^3.0.0"
     prop-types "^15.7.2"
 
+gatsby-plugin-csp@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-csp/-/gatsby-plugin-csp-1.1.3.tgz#27258c0f9b94cf17c55b4d42e520de9870031254"
+  integrity sha512-jTAdWpJXCAaqBXAmf07XVnsgHp7tdtC36XrOQUMRMrEOkEIpM+x+4X3Xma4YAmFbuGH+QKRGmbmCCRNhV//EDA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    lodash.flatten "^4.4.0"
+
 gatsby-plugin-env-variables@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-env-variables/-/gatsby-plugin-env-variables-2.0.0.tgz#a5641eb61f00490a4043fb64646ab7a631491712"


### PR DESCRIPTION
Due to a lot dynamic inline scripts from Gatsby build we can't just hardcode the hashes, so I had to use this plugin to generate them during build time.
Downside: it uses meta tag instead of generating headers file for Netlify, so we can't use report-uri here and some other attributes. Theoretically we could adapt it so it generates headers file an merges it's content but I think it would be an overhead at this point

Closes WEB-163